### PR TITLE
fix: process last bin during skeleton building even if containing only one fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,7 @@ tests/testcases/*/fragments.plot.end.html
 tests/testcases/*/fragments.plot.internal.html
 tests/testcases/*/fragments.plot.start.html
 tests/testcases/*/fragments.preprocessed.meta.yaml
-tests/testcases/*/fragments.prediction.fasta
-tests/testcases/*/fragments.prediction.tsv
+tests/testcases/*/fragments.prediction.*
 tests/testcases/*/fragments.raw
 tests/testcases/*/fragments.singletons.tsv
 tests/testcases/*/fragments.standard_unit_fragments.tsv

--- a/src/python/spectrseqtools/prediction/skeleton_building.py
+++ b/src/python/spectrseqtools/prediction/skeleton_building.py
@@ -136,14 +136,10 @@ class SkeletonBuilder:
         invalid_list = []
         last_valid_bin = None
         bins = fragments.bin(tolerance=self.inferrer.tolerance)
-        for bin_idx, current_bin in enumerate(bins):
+        for current_bin in bins:
             # Stop if no positions are left to fill
             if len(pos) == 0:
                 invalid_list += current_bin.invalidate()
-                continue
-
-            # TODO: This condition imitates bug found in previous code; remove it
-            if (bin_idx + 1 == len(bins)) & (len(current_bin) == 1):
                 continue
 
             compositions = self.infer_compositions_for_bin_differences(


### PR DESCRIPTION
Fix bug found during refactoring that omits last bin during skeleton building if it only contains one element. 